### PR TITLE
asciinema 패키지 설치를 추가하고 리드미를 수정했습니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Include packages
 ## HamoniKR (>= 4.0)
 ```
 sudo apt update
-sudo apt hamonikr-cli-tools
+sudo apt install hamonikr-cli-tools
 ```
 
 ## Ubuntu, LinuxMint (>=Ubuntu 20.04)
 
 ```
 wget -qO- https://pkg.hamonikr.org/add-hamonikr.apt | sudo -E bash -
-sudo apt hamonikr-cli-tools
+sudo apt install hamonikr-cli-tools
 ```
 
 # Remove

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Package: hamonikr-cli-tools
 Architecture: all
 Depends: npm
 Recommends: aria2,
+	    asciinema,
             fonts-naver-d2coding,
             fsarchiver,
             glances,


### PR DESCRIPTION
변경사항은 다음과 같습니다.
- hamonikr-cli-tools 설치시 asciinema 패키지가 설치되지 않는 버그가 발견되어 debian/control 파일의 Recommends 항목에 asciinema 를 추가했습니다.
- 리드미의 설치 명령어에 install이 누락되어 수정하였습니다.